### PR TITLE
Use native arm64 runner instead of qemu

### DIFF
--- a/.github/workflows/image_build.yaml
+++ b/.github/workflows/image_build.yaml
@@ -11,20 +11,20 @@ on:
   schedule:
     - cron:  '30 2 * * 0'
 
-env: 
-  PLATFORMS: linux/arm64,linux/amd64
-
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        os:
+          - ubuntu-24.04-arm
+          - ubuntu-24.04
+    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name: prepare
         run: |
           echo "DATE=$(date +%Y%m%d)" >>$GITHUB_ENV
-      - name: setup-qemu
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf # v3
       - name: setup-buildx
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3
       - name: login-docker
@@ -38,7 +38,6 @@ jobs:
           context: .
           build-args: |
             CACHEBUST=${{ env.DATE }}
-          platforms: ${{ env.PLATFORMS }}
           file: base.Dockerfile
           push: true
           tags: manjarolinux/base:${{ env.DATE }},manjarolinux/base:latest
@@ -50,26 +49,13 @@ jobs:
           context: .
           build-args: |
             CACHEBUST=${{ env.DATE }}
-          platforms: ${{ env.PLATFORMS }}
           file: build.Dockerfile
           push: true
           tags: manjarolinux/build:${{ env.DATE }},manjarolinux/build:latest
-      - name: qemu-setup
+      - name: test
         run: |
-          sudo apt-get update
-          sudo apt-get install qemu binfmt-support qemu-user-static
-          docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-      - name: test-amd64
-        run: |
-          docker run --rm -t --platform=amd64 manjarolinux/base:latest uname -a
-          docker run --rm -t --platform=amd64 manjarolinux/base:latest pacman --noconfirm -S base-devel
+          docker run --rm -t manjarolinux/base:latest uname -a
+          docker run --rm -t manjarolinux/base:latest pacman --noconfirm -S base-devel
 
-          docker run --rm -t --platform=amd64 manjarolinux/build:latest uname -a
-          docker run --rm -t --platform=amd64 manjarolinux/build:latest pacman --noconfirm -S python-pip
-      - name: test-arm64
-        run: |
-          docker run --rm -t --platform=arm64 manjarolinux/base:latest uname -a
-          docker run --rm -t --platform=arm64 manjarolinux/base:latest pacman --noconfirm -S base-devel
-
-          docker run --rm -t --platform=arm64 manjarolinux/build:latest uname -a
-          docker run --rm -t --platform=arm64 manjarolinux/build:latest pacman --noconfirm -S python-pip
+          docker run --rm -t manjarolinux/build:latest uname -a
+          docker run --rm -t manjarolinux/build:latest pacman --noconfirm -S python-pip


### PR DESCRIPTION
Availability of this runner is mentioned in
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/